### PR TITLE
Remove automatic URL encoding.

### DIFF
--- a/source/core/util.c
+++ b/source/core/util.c
@@ -688,39 +688,6 @@ u16* util_select_bnr_title(BNR* bnr) {
 #define MAKE_HTTP_USER_AGENT(major, minor, micro) MAKE_HTTP_USER_AGENT_(major, minor, micro)
 #define HTTP_USER_AGENT MAKE_HTTP_USER_AGENT(VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO)
 
-static char util_dec2hex(u8 c) {
-    if(c >= 0 && c <= 9) {
-        return (char) ('0' + c);
-    } else if(c >= 10 && c <= 15) {
-        return (char) ('A' + (c - 10));
-    } else {
-        return -1;
-    }
-}
-
-static void util_encode_url(char* out, const char* in, size_t size) {
-    u32 pos = 0;
-    size_t len = strlen(in);
-    for(u32 i = 0; i < len && pos < size; i++) {
-        char c = in[i];
-        if((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == ':' || c == '/' || c == '.' || c == '%' || c == '+' || c == '?' || c == '=' || c == '&' || c == '#') {
-            out[pos++] = c;
-        } else {
-            out[pos++] = '%';
-
-            if(pos < size) {
-                out[pos++] = util_dec2hex((u8) (((u8) c) / 16));
-            }
-
-            if(pos < size) {
-                out[pos++] = util_dec2hex((u8) (((u8) c) % 16));
-            }
-        }
-    }
-
-    out[pos < size ? pos : size - 1] = '\0';
-}
-
 Result util_http_open(httpcContext* context, u32* responseCode, const char* url, bool userAgent) {
     return util_http_open_ranged(context, responseCode, url, userAgent, 0, 0);
 }
@@ -731,7 +698,7 @@ Result util_http_open_ranged(httpcContext* context, u32* responseCode, const cha
     }
 
     char currUrl[1024];
-    util_encode_url(currUrl, url, sizeof(currUrl));
+    strncpy(currUrl, url, sizeof(currUrl));
 
     char range[64];
     if(rangeEnd > rangeStart) {


### PR DESCRIPTION
URL encoding should only be performed on parameters, and thus should be
done by the provider of the URL ahead of time.